### PR TITLE
优化跨维度命令树去重与 KeepAlive 低延迟发送

### DIFF
--- a/common/src/main/java/com/PinkCats/bandwidthoptimizer/channel/ChannelTransportStreamingEpochGate.java
+++ b/common/src/main/java/com/PinkCats/bandwidthoptimizer/channel/ChannelTransportStreamingEpochGate.java
@@ -23,11 +23,11 @@ public final class ChannelTransportStreamingEpochGate {
 
     public static boolean deferIfClosed(
             ChannelHandlerContext context,
-            boolean internalTransportCarrier,
+            boolean bypassClosedGate,
             ByteBuf out,
             int startIndexInclusive
     ) {
-        return deferIfClosed(context, internalTransportCarrier, out, startIndexInclusive, null);
+        return deferIfClosed(context, bypassClosedGate, out, startIndexInclusive, null);
     }
 
     public static void closeForEpoch(Channel channel, int epoch, int lastSequence) {
@@ -39,7 +39,7 @@ public final class ChannelTransportStreamingEpochGate {
 
     public static boolean deferIfClosed(
             ChannelHandlerContext context,
-            boolean internalTransportCarrier,
+            boolean bypassClosedGate,
             ByteBuf out,
             int startIndexInclusive,
             Consumer<byte[]> onDeferred
@@ -48,7 +48,7 @@ public final class ChannelTransportStreamingEpochGate {
             return false;
         }
         State state = context.channel().attr(STATE_KEY).get();
-        if (state == null || internalTransportCarrier) {
+        if (state == null || bypassClosedGate) {
             return false;
         }
         int length = out.writerIndex() - startIndexInclusive;

--- a/common/src/main/java/com/PinkCats/bandwidthoptimizer/channel/packet/ChannelTransportBypassPacketList.java
+++ b/common/src/main/java/com/PinkCats/bandwidthoptimizer/channel/packet/ChannelTransportBypassPacketList.java
@@ -97,4 +97,17 @@ public final class ChannelTransportBypassPacketList {
                         || CLIENTBOUND_KEEP_ALIVE_PACKET_CLASS_NAMES.contains(packet.getClass().getName())
         );
     }
+
+    /**
+     * KeepAlive has no ordering dependency on PLAY state and may pass BO-owned queues while a
+     * transport batch or streaming recovery epoch is pending. Already submitted Netty writes keep
+     * their normal order; this policy never reorders data inside Netty's outbound buffer.
+     */
+    public static boolean mayOvertakePendingTransportBatch(Packet<?> packet) {
+        return packet != null && mayOvertakePendingTransportBatch(packet.getClass().getName());
+    }
+
+    static boolean mayOvertakePendingTransportBatch(String packetClassName) {
+        return packetClassName != null && CLIENTBOUND_KEEP_ALIVE_PACKET_CLASS_NAMES.contains(packetClassName);
+    }
 }

--- a/common/src/main/java/com/PinkCats/bandwidthoptimizer/channel/packet/ClientboundCommandTreeDeduplicator.java
+++ b/common/src/main/java/com/PinkCats/bandwidthoptimizer/channel/packet/ClientboundCommandTreeDeduplicator.java
@@ -1,0 +1,282 @@
+package com.PinkCats.bandwidthoptimizer.channel.packet;
+
+import com.PinkCats.bandwidthoptimizer.Bandwidthoptimizer;
+import com.PinkCats.bandwidthoptimizer.Config;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.AttributeKey;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.PacketFlow;
+
+import java.nio.ByteBuffer;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Drops command trees with the same encoded length and SHA-256 fingerprint after the first
+ * successful outbound encode on a connection.
+ *
+ * <p>The fingerprint is calculated from the final, player-specific packet bytes. This intentionally
+ * avoids comparing the server dispatcher or permission metadata before Minecraft has filtered and
+ * encoded it for the receiving player.</p>
+ */
+public final class ClientboundCommandTreeDeduplicator {
+
+    private static final String COMMANDS_PACKET_CLASS_NAME =
+            "net.minecraft.network.protocol.game.ClientboundCommandsPacket";
+    private static final String LOGIN_PACKET_CLASS_NAME =
+            "net.minecraft.network.protocol.game.ClientboundLoginPacket";
+    private static final String START_CONFIGURATION_PACKET_CLASS_NAME =
+            "net.minecraft.network.protocol.configuration.ClientboundStartConfigurationPacket";
+    private static final String COMMON_START_CONFIGURATION_PACKET_CLASS_NAME =
+            "net.minecraft.network.protocol.common.ClientboundStartConfigurationPacket";
+
+    private static final AttributeKey<State> STATE_KEY =
+            AttributeKey.valueOf("bandwidthoptimizer:clientbound_command_tree_deduplicator");
+    private static final ThreadLocal<MessageDigest> SHA_256 = ThreadLocal.withInitial(
+            ClientboundCommandTreeDeduplicator::newSha256
+    );
+    private static final AtomicBoolean HASH_FAILURE_REPORTED = new AtomicBoolean();
+    private static final LongAdder HASHED_TREES = new LongAdder();
+    private static final LongAdder HASHED_BYTES = new LongAdder();
+    private static final LongAdder HASH_NANOS = new LongAdder();
+    private static final LongAdder SENT_TREES = new LongAdder();
+    private static final LongAdder DEDUPLICATED_TREES = new LongAdder();
+    private static final LongAdder DEDUPLICATED_BYTES = new LongAdder();
+    private static final LongAdder RESET_EPOCHS = new LongAdder();
+    private static final LongAdder HASH_FAILURES = new LongAdder();
+
+    private ClientboundCommandTreeDeduplicator() {}
+
+    /**
+     * Observes an encoded packet and removes it from {@code out} only when its final bytes have the
+     * same length and SHA-256 fingerprint as the most recently sent command tree for the same
+     * channel epoch.
+     */
+    public static boolean tryDropDuplicate(
+            ChannelHandlerContext context,
+            Packet<?> packet,
+            PacketFlow packetFlow,
+            ByteBuf out,
+            int startIndexInclusive
+    ) {
+        if (context == null || packet == null || out == null) {
+            return false;
+        }
+
+        return tryDropDuplicate(
+                context.channel(),
+                packet.getClass().getName(),
+                packetFlow,
+                out,
+                startIndexInclusive
+        );
+    }
+
+    static boolean tryDropDuplicate(
+            Channel channel,
+            String packetClassName,
+            PacketFlow packetFlow,
+            ByteBuf out,
+            int startIndexInclusive
+    ) {
+        if (channel == null || packetClassName == null || out == null) {
+            return false;
+        }
+
+        if (isConnectionEpochBoundary(packetClassName)) {
+            reset(channel);
+            return false;
+        }
+        if (packetFlow != PacketFlow.CLIENTBOUND || !COMMANDS_PACKET_CLASS_NAME.equals(packetClassName)) {
+            return false;
+        }
+        if (!isEnabled()) {
+            resetWithoutTelemetry(channel);
+            return false;
+        }
+
+        int encodedLength = out.writerIndex() - startIndexInclusive;
+        if (encodedLength <= 0) {
+            return false;
+        }
+
+        long hashStartNanos = System.nanoTime();
+        byte[] digest = fingerprint(out, startIndexInclusive, encodedLength);
+        HASH_NANOS.add(Math.max(System.nanoTime() - hashStartNanos, 0L));
+        if (digest == null) {
+            HASH_FAILURES.increment();
+            return false;
+        }
+        HASHED_TREES.increment();
+        HASHED_BYTES.add(encodedLength);
+
+        Decision decision = state(channel).evaluate(new Fingerprint(encodedLength, digest));
+        if (decision == Decision.DUPLICATE) {
+            DEDUPLICATED_TREES.increment();
+            DEDUPLICATED_BYTES.add(encodedLength);
+            out.writerIndex(startIndexInclusive);
+            return true;
+        }
+
+        SENT_TREES.increment();
+        return false;
+    }
+
+    public static TelemetrySnapshot telemetrySnapshot() {
+        return new TelemetrySnapshot(
+                HASHED_TREES.sum(),
+                HASHED_BYTES.sum(),
+                HASH_NANOS.sum(),
+                SENT_TREES.sum(),
+                DEDUPLICATED_TREES.sum(),
+                DEDUPLICATED_BYTES.sum(),
+                RESET_EPOCHS.sum(),
+                HASH_FAILURES.sum()
+        );
+    }
+
+    public static void reset(Channel channel) {
+        if (channel == null) {
+            return;
+        }
+        State existingState = channel.attr(STATE_KEY).get();
+        if (existingState != null && existingState.reset()) {
+            RESET_EPOCHS.increment();
+        }
+    }
+
+    static boolean isConnectionEpochBoundary(String packetClassName) {
+        return LOGIN_PACKET_CLASS_NAME.equals(packetClassName)
+                || START_CONFIGURATION_PACKET_CLASS_NAME.equals(packetClassName)
+                || COMMON_START_CONFIGURATION_PACKET_CLASS_NAME.equals(packetClassName);
+    }
+
+    static void resetTelemetryForTests() {
+        HASHED_TREES.reset();
+        HASHED_BYTES.reset();
+        HASH_NANOS.reset();
+        SENT_TREES.reset();
+        DEDUPLICATED_TREES.reset();
+        DEDUPLICATED_BYTES.reset();
+        RESET_EPOCHS.reset();
+        HASH_FAILURES.reset();
+        HASH_FAILURE_REPORTED.set(false);
+    }
+
+    private static boolean isEnabled() {
+        return Boolean.parseBoolean(System.getProperty(
+                Config.RuntimeProperty.Transport.COMMAND_TREE_DEDUP_ENABLED,
+                Boolean.toString(Config.RuntimeProperty.Transport.DEFAULT_COMMAND_TREE_DEDUP_ENABLED)
+        ));
+    }
+
+    private static State state(Channel channel) {
+        State existingState = channel.attr(STATE_KEY).get();
+        if (existingState != null) {
+            return existingState;
+        }
+        State newState = new State();
+        State racedState = channel.attr(STATE_KEY).setIfAbsent(newState);
+        return racedState == null ? newState : racedState;
+    }
+
+    private static void resetWithoutTelemetry(Channel channel) {
+        if (channel == null) {
+            return;
+        }
+        State existingState = channel.attr(STATE_KEY).get();
+        if (existingState != null) {
+            existingState.reset();
+        }
+    }
+
+    private static byte[] fingerprint(ByteBuf buffer, int startIndexInclusive, int length) {
+        try {
+            MessageDigest digest = SHA_256.get();
+            digest.reset();
+            int nioBufferCount = buffer.nioBufferCount();
+            if (nioBufferCount == 1) {
+                digest.update(buffer.nioBuffer(startIndexInclusive, length));
+            } else if (nioBufferCount > 1) {
+                for (ByteBuffer byteBuffer : buffer.nioBuffers(startIndexInclusive, length)) {
+                    digest.update(byteBuffer);
+                }
+            } else {
+                byte[] encodedBytes = new byte[length];
+                buffer.getBytes(startIndexInclusive, encodedBytes);
+                digest.update(encodedBytes);
+            }
+            return digest.digest();
+        } catch (RuntimeException exception) {
+            if (HASH_FAILURE_REPORTED.compareAndSet(false, true)) {
+                Bandwidthoptimizer.LOGGER.warn(
+                        "[Transport][CommandTreeDedup] SHA-256 fingerprint failed; command trees will pass through",
+                        exception
+                );
+            }
+            return null;
+        }
+    }
+
+    private static MessageDigest newSha256() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256 is unavailable", exception);
+        }
+    }
+
+    private enum Decision {
+        SEND,
+        DUPLICATE
+    }
+
+    private record Fingerprint(int encodedLength, byte[] sha256) {
+        private Fingerprint {
+            sha256 = Arrays.copyOf(sha256, sha256.length);
+        }
+
+        private boolean matches(Fingerprint other) {
+            return other != null
+                    && this.encodedLength == other.encodedLength
+                    && MessageDigest.isEqual(this.sha256, other.sha256);
+        }
+    }
+
+    private static final class State {
+        private final AtomicReference<Fingerprint> lastSentFingerprint = new AtomicReference<>();
+
+        private Decision evaluate(Fingerprint fingerprint) {
+            while (true) {
+                Fingerprint existingFingerprint = this.lastSentFingerprint.get();
+                if (existingFingerprint != null && existingFingerprint.matches(fingerprint)) {
+                    return Decision.DUPLICATE;
+                }
+                if (this.lastSentFingerprint.compareAndSet(existingFingerprint, fingerprint)) {
+                    return Decision.SEND;
+                }
+            }
+        }
+
+        private boolean reset() {
+            return this.lastSentFingerprint.getAndSet(null) != null;
+        }
+    }
+
+    public record TelemetrySnapshot(
+            long hashedTrees,
+            long hashedBytes,
+            long hashNanos,
+            long sentTrees,
+            long deduplicatedTrees,
+            long deduplicatedBytes,
+            long resetEpochs,
+            long hashFailures
+    ) {}
+}

--- a/common/src/main/java/com/PinkCats/bandwidthoptimizer/chunk/integration/transport/ChunkTransportBoundaryController.java
+++ b/common/src/main/java/com/PinkCats/bandwidthoptimizer/chunk/integration/transport/ChunkTransportBoundaryController.java
@@ -4,6 +4,7 @@ import com.PinkCats.bandwidthoptimizer.debug.DiagnosticLog;
 
 import com.PinkCats.bandwidthoptimizer.Bandwidthoptimizer;
 import com.PinkCats.bandwidthoptimizer.Config;
+import com.PinkCats.bandwidthoptimizer.channel.packet.ChannelTransportBypassPacketList;
 import com.PinkCats.bandwidthoptimizer.chunk.PeerState.ChunkPeerStateManager;
 import com.PinkCats.bandwidthoptimizer.chunk.classify.packet.ChunkPacketCoordinate;
 import com.PinkCats.bandwidthoptimizer.chunk.classify.packet.ChunkPacketDescriptor;
@@ -51,11 +52,6 @@ public final class ChunkTransportBoundaryController {
     private static final long CHUNK_FAILURE_DISABLE_NANOS = TimeUnit.SECONDS.toNanos(15L);
     private static final long CHANNEL_FAILURE_WINDOW_NANOS = TimeUnit.SECONDS.toNanos(60L);
     private static final long CHANNEL_FAILURE_DISABLE_NANOS = TimeUnit.SECONDS.toNanos(20L);
-    private static final java.util.Set<String> CLIENTBOUND_KEEP_ALIVE_PACKET_CLASS_NAMES = java.util.Set.of(
-            "net.minecraft.network.protocol.common.ClientboundKeepAlivePacket",
-            "net.minecraft.network.protocol.game.ClientboundKeepAlivePacket"
-    );
-
     private ChunkTransportBoundaryController() {}
 
 
@@ -261,9 +257,9 @@ public final class ChunkTransportBoundaryController {
                     "bundle_boundary"
             );
         }
-        if (packet != null && CLIENTBOUND_KEEP_ALIVE_PACKET_CLASS_NAMES.contains(packet.getClass().getName())) {
+        if (ChannelTransportBypassPacketList.mayOvertakePendingTransportBatch(packet)) {
             return new BoundaryTrigger(
-                    true,
+                    false,
                     KEEP_ALIVE_WARMUP_CHUNK_PACKETS,
                     KEEP_ALIVE_MIN_BYPASS_NANOS,
                     false,

--- a/common/src/test/java/com/PinkCats/bandwidthoptimizer/channel/packet/ClientboundCommandTreeDeduplicatorRegressionMain.java
+++ b/common/src/test/java/com/PinkCats/bandwidthoptimizer/channel/packet/ClientboundCommandTreeDeduplicatorRegressionMain.java
@@ -1,0 +1,338 @@
+package com.PinkCats.bandwidthoptimizer.channel.packet;
+
+import com.PinkCats.bandwidthoptimizer.Config;
+import com.PinkCats.bandwidthoptimizer.channel.ChannelTransportStreamingEpochGate;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
+import net.minecraft.network.protocol.PacketFlow;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+public final class ClientboundCommandTreeDeduplicatorRegressionMain {
+
+    private static final String COMMANDS_PACKET =
+            "net.minecraft.network.protocol.game.ClientboundCommandsPacket";
+    private static final String LOGIN_PACKET =
+            "net.minecraft.network.protocol.game.ClientboundLoginPacket";
+    private static final String START_CONFIGURATION_PACKET =
+            "net.minecraft.network.protocol.configuration.ClientboundStartConfigurationPacket";
+    private static final int PREFIX_BYTES = 3;
+    private static final int COMMAND_TREE_BYTES = 130 * 1024;
+
+    private ClientboundCommandTreeDeduplicatorRegressionMain() {}
+
+    public static void main(String[] args) throws Exception {
+        String propertyName = Config.RuntimeProperty.Transport.COMMAND_TREE_DEDUP_ENABLED;
+        String previousProperty = System.getProperty(propertyName);
+        try {
+            System.clearProperty(propertyName);
+            verifyContentAndEpochSemantics(propertyName);
+            verifyConcurrentFirstWriterWins();
+            verifyKeepAliveCanPassBoOwnedQueues();
+            System.out.println("Clientbound command-tree deduplication and KeepAlive priority regression passed");
+        } finally {
+            restoreProperty(propertyName, previousProperty);
+        }
+    }
+
+    private static void verifyContentAndEpochSemantics(String propertyName) {
+        ClientboundCommandTreeDeduplicator.resetTelemetryForTests();
+        EmbeddedChannel firstChannel = new EmbeddedChannel();
+        EmbeddedChannel secondChannel = new EmbeddedChannel();
+        byte[] treeA = commandTreeBytes(0x31);
+        byte[] treeB = commandTreeBytes(0x57);
+
+        try {
+            assertPasses(firstChannel, COMMANDS_PACKET, PacketFlow.CLIENTBOUND, treeA, false, "first tree");
+            assertDropsComposite(firstChannel, treeA, "byte-identical tree");
+            assertPasses(firstChannel, COMMANDS_PACKET, PacketFlow.CLIENTBOUND, treeB, false, "same-length changed tree");
+            assertPasses(firstChannel, COMMANDS_PACKET, PacketFlow.CLIENTBOUND, treeA, false, "changed-back tree");
+            assertDrops(firstChannel, COMMANDS_PACKET, PacketFlow.CLIENTBOUND, treeA, "second identical tree");
+
+            assertPasses(firstChannel, COMMANDS_PACKET, PacketFlow.SERVERBOUND, treeA, false, "wrong packet flow");
+            assertDrops(firstChannel, COMMANDS_PACKET, PacketFlow.CLIENTBOUND, treeA, "wrong flow must not reset state");
+
+            assertPasses(firstChannel, LOGIN_PACKET, PacketFlow.CLIENTBOUND, new byte[] {1}, false, "login boundary");
+            assertPasses(firstChannel, COMMANDS_PACKET, PacketFlow.CLIENTBOUND, treeA, false, "first tree after login");
+            assertPasses(
+                    firstChannel,
+                    START_CONFIGURATION_PACKET,
+                    PacketFlow.CLIENTBOUND,
+                    new byte[] {2},
+                    false,
+                    "configuration boundary"
+            );
+            assertPasses(firstChannel, COMMANDS_PACKET, PacketFlow.CLIENTBOUND, treeA, false, "first tree after reconfiguration");
+
+            System.setProperty(propertyName, "false");
+            assertPasses(firstChannel, COMMANDS_PACKET, PacketFlow.CLIENTBOUND, treeA, false, "disabled first tree");
+            assertPasses(firstChannel, COMMANDS_PACKET, PacketFlow.CLIENTBOUND, treeA, false, "disabled duplicate tree");
+            System.setProperty(propertyName, "true");
+            assertPasses(firstChannel, COMMANDS_PACKET, PacketFlow.CLIENTBOUND, treeA, false, "re-enabled first tree");
+            assertDrops(firstChannel, COMMANDS_PACKET, PacketFlow.CLIENTBOUND, treeA, "re-enabled duplicate tree");
+
+            assertPasses(secondChannel, COMMANDS_PACKET, PacketFlow.CLIENTBOUND, treeA, false, "independent channel first tree");
+            assertDrops(secondChannel, COMMANDS_PACKET, PacketFlow.CLIENTBOUND, treeA, "independent channel duplicate tree");
+
+            ClientboundCommandTreeDeduplicator.TelemetrySnapshot snapshot =
+                    ClientboundCommandTreeDeduplicator.telemetrySnapshot();
+            assertEquals(12L, snapshot.hashedTrees(), "hashed tree count");
+            assertEquals(12L * treeA.length, snapshot.hashedBytes(), "hashed byte count");
+            assertEquals(7L, snapshot.sentTrees(), "sent tree count");
+            assertEquals(5L, snapshot.deduplicatedTrees(), "deduplicated tree count");
+            assertEquals(5L * treeA.length, snapshot.deduplicatedBytes(), "deduplicated byte count");
+            assertEquals(2L, snapshot.resetEpochs(), "connection epoch reset count");
+            assertEquals(0L, snapshot.hashFailures(), "hash failure count");
+        } finally {
+            firstChannel.finishAndReleaseAll();
+            secondChannel.finishAndReleaseAll();
+        }
+    }
+
+    private static void verifyConcurrentFirstWriterWins() throws Exception {
+        ClientboundCommandTreeDeduplicator.resetTelemetryForTests();
+        EmbeddedChannel channel = new EmbeddedChannel();
+        byte[] tree = commandTreeBytes(0x6d);
+        int workers = 12;
+        ExecutorService executor = Executors.newFixedThreadPool(workers);
+        CountDownLatch ready = new CountDownLatch(workers);
+        CountDownLatch start = new CountDownLatch(1);
+        AtomicInteger sent = new AtomicInteger();
+        AtomicInteger dropped = new AtomicInteger();
+        List<Future<?>> futures = new ArrayList<>();
+
+        try {
+            for (int index = 0; index < workers; index++) {
+                futures.add(executor.submit(() -> {
+                    ready.countDown();
+                    await(start);
+                    ByteBuf buffer = encodedBuffer(tree);
+                    try {
+                        if (ClientboundCommandTreeDeduplicator.tryDropDuplicate(
+                                channel,
+                                COMMANDS_PACKET,
+                                PacketFlow.CLIENTBOUND,
+                                buffer,
+                                PREFIX_BYTES
+                        )) {
+                            dropped.incrementAndGet();
+                        } else {
+                            sent.incrementAndGet();
+                        }
+                    } finally {
+                        buffer.release();
+                    }
+                }));
+            }
+            await(ready);
+            start.countDown();
+            for (Future<?> future : futures) {
+                future.get(10L, TimeUnit.SECONDS);
+            }
+            assertEquals(1L, sent.get(), "concurrent first send count");
+            assertEquals(workers - 1L, dropped.get(), "concurrent duplicate count");
+        } finally {
+            start.countDown();
+            executor.shutdownNow();
+            try {
+                if (!executor.awaitTermination(5L, TimeUnit.SECONDS)) {
+                    throw new AssertionError("concurrency regression workers did not terminate");
+                }
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                throw new AssertionError("interrupted while stopping concurrency regression workers", exception);
+            }
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    private static void verifyKeepAliveCanPassBoOwnedQueues() {
+        assertTrue(
+                ChannelTransportBypassPacketList.mayOvertakePendingTransportBatch(
+                        "net.minecraft.network.protocol.common.ClientboundKeepAlivePacket"
+                ),
+                "modern KeepAlive must overtake a pending BO batch"
+        );
+        assertTrue(
+                ChannelTransportBypassPacketList.mayOvertakePendingTransportBatch(
+                        "net.minecraft.network.protocol.game.ClientboundKeepAlivePacket"
+                ),
+                "legacy KeepAlive must overtake a pending BO batch"
+        );
+        assertFalse(
+                ChannelTransportBypassPacketList.mayOvertakePendingTransportBatch(COMMANDS_PACKET),
+                "command trees must retain normal packet ordering"
+        );
+
+        AtomicReference<ChannelHandlerContext> contextReference = new AtomicReference<>();
+        EmbeddedChannel channel = new EmbeddedChannel(new ChannelOutboundHandlerAdapter() {
+            @Override
+            public void handlerAdded(ChannelHandlerContext context) {
+                contextReference.set(context);
+            }
+        });
+        ChannelHandlerContext context = contextReference.get();
+        if (context == null) {
+            throw new AssertionError("embedded channel did not expose an outbound context");
+        }
+
+        ByteBuf keepAlive = Unpooled.wrappedBuffer(new byte[] {1, 2, 3});
+        ByteBuf orderedState = Unpooled.wrappedBuffer(new byte[] {4, 5, 6});
+        try {
+            ChannelTransportStreamingEpochGate.closeForEpoch(channel, 9, 3);
+            assertFalse(
+                    ChannelTransportStreamingEpochGate.deferIfClosed(context, true, keepAlive, 0),
+                    "KeepAlive must not wait for a streaming epoch acknowledgement"
+            );
+            assertEquals(3L, keepAlive.readableBytes(), "KeepAlive bytes must remain available to Netty");
+            assertTrue(
+                    ChannelTransportStreamingEpochGate.deferIfClosed(context, false, orderedState, 0),
+                    "ordered state must remain behind the streaming epoch gate"
+            );
+            assertEquals(0L, orderedState.readableBytes(), "deferred state bytes must leave the encoder buffer");
+            ChannelTransportStreamingEpochGate.release(channel);
+            ByteBuf replayed = channel.readOutbound();
+            if (replayed == null) {
+                throw new AssertionError("streaming epoch gate did not replay ordered state");
+            }
+            try {
+                assertEquals(3L, replayed.readableBytes(), "replayed ordered state byte count");
+                assertEquals(4L, replayed.readUnsignedByte(), "replayed ordered state first byte");
+            } finally {
+                replayed.release();
+            }
+        } finally {
+            keepAlive.release();
+            orderedState.release();
+            ChannelTransportStreamingEpochGate.clear(channel);
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    private static void assertDropsComposite(EmbeddedChannel channel, byte[] tree, String label) {
+        byte[] prefix = new byte[] {0x11, 0x22, 0x33};
+        int split = tree.length / 2;
+        CompositeByteBuf buffer = Unpooled.compositeBuffer();
+        buffer.addComponents(
+                true,
+                Unpooled.wrappedBuffer(prefix),
+                Unpooled.wrappedBuffer(tree, 0, split),
+                Unpooled.wrappedBuffer(tree, split, tree.length - split)
+        );
+        try {
+            boolean dropped = ClientboundCommandTreeDeduplicator.tryDropDuplicate(
+                    channel,
+                    COMMANDS_PACKET,
+                    PacketFlow.CLIENTBOUND,
+                    buffer,
+                    PREFIX_BYTES
+            );
+            assertTrue(dropped, label + " must be dropped");
+            assertEquals(PREFIX_BYTES, buffer.writerIndex(), label + " writer index");
+        } finally {
+            buffer.release();
+        }
+    }
+
+    private static void assertDrops(
+            EmbeddedChannel channel,
+            String packetClassName,
+            PacketFlow packetFlow,
+            byte[] payload,
+            String label
+    ) {
+        assertPasses(channel, packetClassName, packetFlow, payload, true, label);
+    }
+
+    private static void assertPasses(
+            EmbeddedChannel channel,
+            String packetClassName,
+            PacketFlow packetFlow,
+            byte[] payload,
+            boolean expectedDrop,
+            String label
+    ) {
+        ByteBuf buffer = encodedBuffer(payload);
+        int expectedWriterIndex = expectedDrop ? PREFIX_BYTES : PREFIX_BYTES + payload.length;
+        try {
+            boolean dropped = ClientboundCommandTreeDeduplicator.tryDropDuplicate(
+                    channel,
+                    packetClassName,
+                    packetFlow,
+                    buffer,
+                    PREFIX_BYTES
+            );
+            if (dropped != expectedDrop) {
+                throw new AssertionError(label + ": expectedDrop=" + expectedDrop + ", actualDrop=" + dropped);
+            }
+            assertEquals(expectedWriterIndex, buffer.writerIndex(), label + " writer index");
+            assertEquals(0x11L, buffer.getUnsignedByte(0), label + " prefix must remain intact");
+        } finally {
+            buffer.release();
+        }
+    }
+
+    private static ByteBuf encodedBuffer(byte[] payload) {
+        ByteBuf buffer = Unpooled.directBuffer(PREFIX_BYTES + payload.length);
+        buffer.writeByte(0x11);
+        buffer.writeByte(0x22);
+        buffer.writeByte(0x33);
+        buffer.writeBytes(payload);
+        return buffer;
+    }
+
+    private static byte[] commandTreeBytes(int seed) {
+        byte[] bytes = new byte[COMMAND_TREE_BYTES];
+        for (int index = 0; index < bytes.length; index++) {
+            bytes[index] = (byte) (seed + index * 31);
+        }
+        return bytes;
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            if (!latch.await(10L, TimeUnit.SECONDS)) {
+                throw new AssertionError("timed out while waiting for regression barrier");
+            }
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("interrupted while waiting for regression barrier", exception);
+        }
+    }
+
+    private static void restoreProperty(String propertyName, String previousValue) {
+        if (previousValue == null) {
+            System.clearProperty(propertyName);
+        } else {
+            System.setProperty(propertyName, previousValue);
+        }
+    }
+
+    private static void assertTrue(boolean value, String message) {
+        if (!value) {
+            throw new AssertionError(message);
+        }
+    }
+
+    private static void assertFalse(boolean value, String message) {
+        assertTrue(!value, message);
+    }
+
+    private static void assertEquals(long expected, long actual, String message) {
+        if (expected != actual) {
+            throw new AssertionError(message + ": expected=" + expected + ", actual=" + actual);
+        }
+    }
+}

--- a/project/fabric/1.20.1/build.gradle
+++ b/project/fabric/1.20.1/build.gradle
@@ -79,6 +79,7 @@ if (standaloneFabricBuild) {
             ['runChannelTransportReport', 'verification', 'Runs Fabric 1.20.1 transport report scenarios.'],
             ['runChannelTransportRoundTrip', 'verification', 'Verifies Fabric 1.20.1 transport codec round trips.'],
             ['runCrossFrameZstdRegression', 'verification', 'Verifies Fabric 1.20.1 cross-frame Zstd reuse and recovery.'],
+            ['runClientboundCommandTreeDeduplicatorRegression', 'verification', 'Verifies Fabric 1.20.1 command-tree deduplication and KeepAlive priority.'],
             ['runChunkBranchCoverageVerify', 'verification', 'Verifies Fabric 1.20.1 chunk branch coverage.'],
             ['runWatchBoundaryRefreshPatchRegression', 'verification', 'Runs Fabric 1.20.1 watch-boundary refresh-patch regression.'],
             ['verifyPublishArtifact', 'Publishing', 'Verifies the Fabric 1.20.1 publish artifact.'],

--- a/project/fabric/1.20.1/src/main/java/com/PinkCats/bandwidthoptimizer/Config.java
+++ b/project/fabric/1.20.1/src/main/java/com/PinkCats/bandwidthoptimizer/Config.java
@@ -294,6 +294,9 @@ public class Config {
             public static final boolean DEFAULT_PACKET_ID_MAPPING_ENABLED = true;
             public static final String BATCH_ENABLED = "bandwidthoptimizer.transport.batchEnabled";
             public static final boolean DEFAULT_BATCH_ENABLED = true;
+            public static final String COMMAND_TREE_DEDUP_ENABLED =
+                    "bandwidthoptimizer.transport.commandTreeDedupEnabled";
+            public static final boolean DEFAULT_COMMAND_TREE_DEDUP_ENABLED = true;
             public static final String BATCH_WINDOW_MILLIS = "bandwidthoptimizer.transport.batchWindowMillis";
             public static final long DEFAULT_BATCH_WINDOW_MILLIS = 20L;
             public static final long DEFAULT_BATCH_WARMUP_MILLIS = 5_000L;

--- a/project/fabric/1.20.1/src/main/java/com/PinkCats/bandwidthoptimizer/channel/ChannelTransportHooks.java
+++ b/project/fabric/1.20.1/src/main/java/com/PinkCats/bandwidthoptimizer/channel/ChannelTransportHooks.java
@@ -1730,7 +1730,9 @@ public final class ChannelTransportHooks {
         if (!ChannelTransportBypassPacketList.shouldBypassTransparentTransport(packet)) {
             return false;
         }
-        ChannelTransportBatchManager.flushOutboundBatchNow(context);
+        if (!ChannelTransportBypassPacketList.mayOvertakePendingTransportBatch(packet)) {
+            ChannelTransportBatchManager.flushOutboundBatchNow(context);
+        }
         return true;
     }
 

--- a/project/fabric/1.20.1/src/main/java/com/PinkCats/bandwidthoptimizer/mixin/minecraft/PacketOutPipeMixin.java
+++ b/project/fabric/1.20.1/src/main/java/com/PinkCats/bandwidthoptimizer/mixin/minecraft/PacketOutPipeMixin.java
@@ -3,6 +3,8 @@ package com.PinkCats.bandwidthoptimizer.mixin.minecraft;
 import com.PinkCats.bandwidthoptimizer.channel.capture.ChannelCaptureHooks;
 import com.PinkCats.bandwidthoptimizer.channel.ChannelTransportHooks;
 import com.PinkCats.bandwidthoptimizer.channel.ChannelTransportStreamingEpochGate;
+import com.PinkCats.bandwidthoptimizer.channel.packet.ChannelTransportBypassPacketList;
+import com.PinkCats.bandwidthoptimizer.channel.packet.ClientboundCommandTreeDeduplicator;
 import com.PinkCats.bandwidthoptimizer.channel.access.PacketEncoderFlowAccess;
 import com.PinkCats.bandwidthoptimizer.debug.HotpathCostProbe;
 import com.PinkCats.bandwidthoptimizer.debug.TransportDiagnosticProbe;
@@ -75,9 +77,19 @@ public abstract class PacketOutPipeMixin<T extends PacketListener> implements Pa
             return;
         }
         IdleGateBackgroundPacketGate.recordPassedPacket(context == null ? null : context.channel(), packet, this.flow, encodedByteLength);
+        if (ClientboundCommandTreeDeduplicator.tryDropDuplicate(
+                context,
+                packet,
+                this.flow,
+                out,
+                this.bandwidthoptimizer$writerIndexBefore
+        )) {
+            return;
+        }
         if (ChannelTransportStreamingEpochGate.deferIfClosed(
                 context,
-                ChannelTransportHooks.isInternalTransportCarrierPacket(packet),
+                ChannelTransportHooks.isInternalTransportCarrierPacket(packet)
+                        || ChannelTransportBypassPacketList.mayOvertakePendingTransportBatch(packet),
                 out,
                 this.bandwidthoptimizer$writerIndexBefore,
                 bytes -> ChannelTransportHooks.recordCommittedOutboundPacketStream(context, packet, bytes)

--- a/project/fabric/1.21.1/build.gradle
+++ b/project/fabric/1.21.1/build.gradle
@@ -79,6 +79,7 @@ if (standaloneFabricBuild) {
             ['runChannelTransportReport', 'verification', 'Runs Fabric 1.21.1 transport report scenarios.'],
             ['runChannelTransportRoundTrip', 'verification', 'Verifies Fabric 1.21.1 transport codec round trips.'],
             ['runCrossFrameZstdRegression', 'verification', 'Verifies Fabric 1.21.1 cross-frame Zstd reuse and recovery.'],
+            ['runClientboundCommandTreeDeduplicatorRegression', 'verification', 'Verifies Fabric 1.21.1 command-tree deduplication and KeepAlive priority.'],
             ['runChunkBranchCoverageVerify', 'verification', 'Verifies Fabric 1.21.1 chunk branch coverage.'],
             ['runWatchBoundaryRefreshPatchRegression', 'verification', 'Runs Fabric 1.21.1 watch-boundary refresh-patch regression.'],
             ['verifyPublishArtifact', 'Publishing', 'Verifies the Fabric 1.21.1 publish artifact.'],

--- a/project/fabric/1.21.1/src/main/java/com/PinkCats/bandwidthoptimizer/Config.java
+++ b/project/fabric/1.21.1/src/main/java/com/PinkCats/bandwidthoptimizer/Config.java
@@ -294,6 +294,9 @@ public class Config {
             public static final boolean DEFAULT_PACKET_ID_MAPPING_ENABLED = true;
             public static final String BATCH_ENABLED = "bandwidthoptimizer.transport.batchEnabled";
             public static final boolean DEFAULT_BATCH_ENABLED = true;
+            public static final String COMMAND_TREE_DEDUP_ENABLED =
+                    "bandwidthoptimizer.transport.commandTreeDedupEnabled";
+            public static final boolean DEFAULT_COMMAND_TREE_DEDUP_ENABLED = true;
             public static final String BATCH_WINDOW_MILLIS = "bandwidthoptimizer.transport.batchWindowMillis";
             public static final long DEFAULT_BATCH_WINDOW_MILLIS = 20L;
             public static final long DEFAULT_BATCH_WARMUP_MILLIS = 5_000L;

--- a/project/fabric/1.21.1/src/main/java/com/PinkCats/bandwidthoptimizer/channel/ChannelTransportHooks.java
+++ b/project/fabric/1.21.1/src/main/java/com/PinkCats/bandwidthoptimizer/channel/ChannelTransportHooks.java
@@ -1774,7 +1774,9 @@ public final class ChannelTransportHooks {
         if (!ChannelTransportBypassPacketList.shouldBypassTransparentTransport(packet)) {
             return false;
         }
-        ChannelTransportBatchManager.flushOutboundBatchNow(context);
+        if (!ChannelTransportBypassPacketList.mayOvertakePendingTransportBatch(packet)) {
+            ChannelTransportBatchManager.flushOutboundBatchNow(context);
+        }
         return true;
     }
 

--- a/project/fabric/1.21.1/src/main/java/com/PinkCats/bandwidthoptimizer/mixin/minecraft/PacketOutPipeMixin.java
+++ b/project/fabric/1.21.1/src/main/java/com/PinkCats/bandwidthoptimizer/mixin/minecraft/PacketOutPipeMixin.java
@@ -3,6 +3,8 @@ package com.PinkCats.bandwidthoptimizer.mixin.minecraft;
 import com.PinkCats.bandwidthoptimizer.channel.capture.ChannelCaptureHooks;
 import com.PinkCats.bandwidthoptimizer.channel.ChannelTransportHooks;
 import com.PinkCats.bandwidthoptimizer.channel.ChannelTransportStreamingEpochGate;
+import com.PinkCats.bandwidthoptimizer.channel.packet.ChannelTransportBypassPacketList;
+import com.PinkCats.bandwidthoptimizer.channel.packet.ClientboundCommandTreeDeduplicator;
 import com.PinkCats.bandwidthoptimizer.channel.access.PacketEncoderFlowAccess;
 import com.PinkCats.bandwidthoptimizer.channel.access.PacketEncoderProtocolInfoAccess;
 import com.PinkCats.bandwidthoptimizer.debug.HotpathCostProbe;
@@ -82,9 +84,19 @@ public abstract class PacketOutPipeMixin<T extends PacketListener> implements Pa
             return;
         }
         IdleGateBackgroundPacketGate.recordPassedPacket(context == null ? null : context.channel(), packet, this.protocolInfo.flow(), encodedByteLength);
+        if (ClientboundCommandTreeDeduplicator.tryDropDuplicate(
+                context,
+                packet,
+                this.protocolInfo.flow(),
+                out,
+                this.bandwidthoptimizer$writerIndexBefore
+        )) {
+            return;
+        }
         if (ChannelTransportStreamingEpochGate.deferIfClosed(
                 context,
-                ChannelTransportHooks.isInternalTransportCarrierPacket(packet),
+                ChannelTransportHooks.isInternalTransportCarrierPacket(packet)
+                        || ChannelTransportBypassPacketList.mayOvertakePendingTransportBatch(packet),
                 out,
                 this.bandwidthoptimizer$writerIndexBefore,
                 bytes -> ChannelTransportHooks.recordCommittedOutboundPacketStream(context, packet, bytes)

--- a/project/forge/1.20.1/src/main/java/com/PinkCats/bandwidthoptimizer/Config.java
+++ b/project/forge/1.20.1/src/main/java/com/PinkCats/bandwidthoptimizer/Config.java
@@ -299,6 +299,9 @@ public class Config {
             public static final boolean DEFAULT_PACKET_ID_MAPPING_ENABLED = true;
             public static final String BATCH_ENABLED = "bandwidthoptimizer.transport.batchEnabled";
             public static final boolean DEFAULT_BATCH_ENABLED = true;
+            public static final String COMMAND_TREE_DEDUP_ENABLED =
+                    "bandwidthoptimizer.transport.commandTreeDedupEnabled";
+            public static final boolean DEFAULT_COMMAND_TREE_DEDUP_ENABLED = true;
             public static final String BATCH_WINDOW_MILLIS = "bandwidthoptimizer.transport.batchWindowMillis";
             public static final long DEFAULT_BATCH_WINDOW_MILLIS = 20L;
             public static final long DEFAULT_BATCH_WARMUP_MILLIS = 5_000L;

--- a/project/forge/1.20.1/src/main/java/com/PinkCats/bandwidthoptimizer/channel/ChannelTransportHooks.java
+++ b/project/forge/1.20.1/src/main/java/com/PinkCats/bandwidthoptimizer/channel/ChannelTransportHooks.java
@@ -1910,7 +1910,9 @@ public final class ChannelTransportHooks {
         if (!ChannelTransportBypassPacketList.shouldBypassTransparentTransport(packet)) {
             return false;
         }
-        ChannelTransportBatchManager.flushOutboundBatchNow(context);
+        if (!ChannelTransportBypassPacketList.mayOvertakePendingTransportBatch(packet)) {
+            ChannelTransportBatchManager.flushOutboundBatchNow(context);
+        }
         return true;
     }
 

--- a/project/forge/1.20.1/src/main/java/com/PinkCats/bandwidthoptimizer/mixin/minecraft/PacketOutPipeMixin.java
+++ b/project/forge/1.20.1/src/main/java/com/PinkCats/bandwidthoptimizer/mixin/minecraft/PacketOutPipeMixin.java
@@ -7,6 +7,8 @@ import com.PinkCats.bandwidthoptimizer.channel.ChannelIdentity;
 import com.PinkCats.bandwidthoptimizer.channel.ChannelTransportHooks;
 import com.PinkCats.bandwidthoptimizer.channel.ChannelTransportStateManager;
 import com.PinkCats.bandwidthoptimizer.channel.ChannelTransportStreamingEpochGate;
+import com.PinkCats.bandwidthoptimizer.channel.packet.ChannelTransportBypassPacketList;
+import com.PinkCats.bandwidthoptimizer.channel.packet.ClientboundCommandTreeDeduplicator;
 import com.PinkCats.bandwidthoptimizer.channel.access.PacketEncoderFlowAccess;
 import com.PinkCats.bandwidthoptimizer.channel.algorithm.batch.ChannelTransportBatchManager;
 import com.PinkCats.bandwidthoptimizer.chunk.budget.ChunkClientTrimmedFullBaseStore;
@@ -121,9 +123,19 @@ public abstract class PacketOutPipeMixin<T extends PacketListener> implements Pa
             return;
         }
         IdleGateBackgroundPacketGate.recordPassedPacket(context == null ? null : context.channel(), packet, this.flow, encodedByteLength);
+        if (ClientboundCommandTreeDeduplicator.tryDropDuplicate(
+                context,
+                packet,
+                this.flow,
+                out,
+                this.bandwidthoptimizer$writerIndexBefore
+        )) {
+            return;
+        }
         if (ChannelTransportStreamingEpochGate.deferIfClosed(
                 context,
-                ChannelTransportHooks.isInternalTransportCarrierPacket(packet),
+                ChannelTransportHooks.isInternalTransportCarrierPacket(packet)
+                        || ChannelTransportBypassPacketList.mayOvertakePendingTransportBatch(packet),
                 out,
                 this.bandwidthoptimizer$writerIndexBefore,
                 bytes -> ChannelTransportHooks.recordCommittedOutboundPacketStream(context, packet, bytes)

--- a/project/neoforge/1.21.1/build.gradle
+++ b/project/neoforge/1.21.1/build.gradle
@@ -59,6 +59,7 @@ def applySharedBandwidthOptimizerNeoForgeRunProperties = { Project projectRef, d
             ['boTransportMappingEnabled', 'bandwidthoptimizer.transport.mappingEnabled'],
             ['boTransportZstdEnabled', 'bandwidthoptimizer.transport.zstdEnabled'],
             ['boTransportBatchEnabled', 'bandwidthoptimizer.transport.batchEnabled'],
+            ['boTransportCommandTreeDedupEnabled', 'bandwidthoptimizer.transport.commandTreeDedupEnabled'],
             ['boTransportBatchWindowMillis', 'bandwidthoptimizer.transport.batchWindowMillis'],
             ['boTransportPacketIdMappingEnabled', 'bandwidthoptimizer.transport.packetIdMappingEnabled'],
             ['boTransportTelemetryDumpFileName', 'bandwidthoptimizer.transport.telemetryDumpFileName'],
@@ -520,6 +521,14 @@ tasks.register('runCrossFrameZstdRegression', JavaExec) {
     dependsOn(tasks.named('testClasses'))
     classpath = files(sourceSets.test.output, sourceSets.main.runtimeClasspath, sourceSets.test.runtimeClasspath)
     mainClass = 'com.PinkCats.bandwidthoptimizer.test.CrossFrameZstdRegressionMain'
+}
+
+tasks.register('runClientboundCommandTreeDeduplicatorRegression', JavaExec) {
+    group = 'verification'
+    description = 'Verifies final-byte command-tree deduplication, connection epochs, concurrency, and KeepAlive queue priority.'
+    dependsOn(tasks.named('testClasses'))
+    classpath = files(sourceSets.test.output, sourceSets.main.runtimeClasspath, sourceSets.test.runtimeClasspath)
+    mainClass = 'com.PinkCats.bandwidthoptimizer.channel.packet.ClientboundCommandTreeDeduplicatorRegressionMain'
 }
 
 tasks.register('runPersistentCacheBloomRegression', JavaExec) {

--- a/project/neoforge/1.21.1/src/main/java/com/PinkCats/bandwidthoptimizer/Config.java
+++ b/project/neoforge/1.21.1/src/main/java/com/PinkCats/bandwidthoptimizer/Config.java
@@ -300,6 +300,9 @@ public class Config {
             public static final boolean DEFAULT_PACKET_ID_MAPPING_ENABLED = true;
             public static final String BATCH_ENABLED = "bandwidthoptimizer.transport.batchEnabled";
             public static final boolean DEFAULT_BATCH_ENABLED = true;
+            public static final String COMMAND_TREE_DEDUP_ENABLED =
+                    "bandwidthoptimizer.transport.commandTreeDedupEnabled";
+            public static final boolean DEFAULT_COMMAND_TREE_DEDUP_ENABLED = true;
             public static final String BATCH_WINDOW_MILLIS = "bandwidthoptimizer.transport.batchWindowMillis";
             public static final long DEFAULT_BATCH_WINDOW_MILLIS = 20L;
             public static final long DEFAULT_BATCH_WARMUP_MILLIS = 5_000L;

--- a/project/neoforge/1.21.1/src/main/java/com/PinkCats/bandwidthoptimizer/channel/ChannelTransportHooks.java
+++ b/project/neoforge/1.21.1/src/main/java/com/PinkCats/bandwidthoptimizer/channel/ChannelTransportHooks.java
@@ -1779,7 +1779,9 @@ public final class ChannelTransportHooks {
         if (!ChannelTransportBypassPacketList.shouldBypassTransparentTransport(packet)) {
             return false;
         }
-        ChannelTransportBatchManager.flushOutboundBatchNow(context);
+        if (!ChannelTransportBypassPacketList.mayOvertakePendingTransportBatch(packet)) {
+            ChannelTransportBatchManager.flushOutboundBatchNow(context);
+        }
         return true;
     }
 

--- a/project/neoforge/1.21.1/src/main/java/com/PinkCats/bandwidthoptimizer/mixin/minecraft/PacketOutPipeMixin.java
+++ b/project/neoforge/1.21.1/src/main/java/com/PinkCats/bandwidthoptimizer/mixin/minecraft/PacketOutPipeMixin.java
@@ -3,6 +3,8 @@ package com.PinkCats.bandwidthoptimizer.mixin.minecraft;
 import com.PinkCats.bandwidthoptimizer.channel.capture.ChannelCaptureHooks;
 import com.PinkCats.bandwidthoptimizer.channel.ChannelTransportHooks;
 import com.PinkCats.bandwidthoptimizer.channel.ChannelTransportStreamingEpochGate;
+import com.PinkCats.bandwidthoptimizer.channel.packet.ChannelTransportBypassPacketList;
+import com.PinkCats.bandwidthoptimizer.channel.packet.ClientboundCommandTreeDeduplicator;
 import com.PinkCats.bandwidthoptimizer.channel.access.PacketEncoderFlowAccess;
 import com.PinkCats.bandwidthoptimizer.channel.access.PacketEncoderProtocolInfoAccess;
 import com.PinkCats.bandwidthoptimizer.debug.HotpathCostProbe;
@@ -85,9 +87,19 @@ public abstract class PacketOutPipeMixin<T extends PacketListener> implements Pa
             return;
         }
         IdleGateBackgroundPacketGate.recordPassedPacket(context == null ? null : context.channel(), packet, this.protocolInfo.flow(), encodedByteLength);
+        if (ClientboundCommandTreeDeduplicator.tryDropDuplicate(
+                context,
+                packet,
+                this.protocolInfo.flow(),
+                out,
+                this.bandwidthoptimizer$writerIndexBefore
+        )) {
+            return;
+        }
         if (ChannelTransportStreamingEpochGate.deferIfClosed(
                 context,
-                ChannelTransportHooks.isInternalTransportCarrierPacket(packet),
+                ChannelTransportHooks.isInternalTransportCarrierPacket(packet)
+                        || ChannelTransportBypassPacketList.mayOvertakePendingTransportBatch(packet),
                 out,
                 this.bandwidthoptimizer$writerIndexBefore,
                 bytes -> ChannelTransportHooks.recordCommittedOutboundPacketStream(context, packet, bytes)

--- a/project/neoforge/26.1.2/build.gradle
+++ b/project/neoforge/26.1.2/build.gradle
@@ -63,6 +63,7 @@ def applySharedBandwidthOptimizerNeoForgeRunProperties = { Project projectRef, d
             ['boTransportMappingEnabled', 'bandwidthoptimizer.transport.mappingEnabled'],
             ['boTransportZstdEnabled', 'bandwidthoptimizer.transport.zstdEnabled'],
             ['boTransportBatchEnabled', 'bandwidthoptimizer.transport.batchEnabled'],
+            ['boTransportCommandTreeDedupEnabled', 'bandwidthoptimizer.transport.commandTreeDedupEnabled'],
             ['boTransportBatchWindowMillis', 'bandwidthoptimizer.transport.batchWindowMillis'],
             ['boTransportPacketIdMappingEnabled', 'bandwidthoptimizer.transport.packetIdMappingEnabled'],
             ['boTransportTelemetryDumpFileName', 'bandwidthoptimizer.transport.telemetryDumpFileName'],
@@ -533,6 +534,15 @@ tasks.register('runCrossFrameZstdRegression', JavaExec) {
     dependsOn(tasks.named('testClasses'))
     classpath = files(sourceSets.test.output, sourceSets.main.runtimeClasspath, sourceSets.test.runtimeClasspath)
     mainClass = 'com.PinkCats.bandwidthoptimizer.test.CrossFrameZstdRegressionMain'
+    javaLauncher = boJava25Launcher
+}
+
+tasks.register('runClientboundCommandTreeDeduplicatorRegression', JavaExec) {
+    group = 'verification'
+    description = 'Verifies final-byte command-tree deduplication, connection epochs, concurrency, and KeepAlive queue priority.'
+    dependsOn(tasks.named('testClasses'))
+    classpath = files(sourceSets.test.output, sourceSets.main.runtimeClasspath, sourceSets.test.runtimeClasspath)
+    mainClass = 'com.PinkCats.bandwidthoptimizer.channel.packet.ClientboundCommandTreeDeduplicatorRegressionMain'
     javaLauncher = boJava25Launcher
 }
 

--- a/project/neoforge/26.1.2/src/main/java/com/PinkCats/bandwidthoptimizer/Config.java
+++ b/project/neoforge/26.1.2/src/main/java/com/PinkCats/bandwidthoptimizer/Config.java
@@ -300,6 +300,9 @@ public class Config {
             public static final boolean DEFAULT_PACKET_ID_MAPPING_ENABLED = true;
             public static final String BATCH_ENABLED = "bandwidthoptimizer.transport.batchEnabled";
             public static final boolean DEFAULT_BATCH_ENABLED = true;
+            public static final String COMMAND_TREE_DEDUP_ENABLED =
+                    "bandwidthoptimizer.transport.commandTreeDedupEnabled";
+            public static final boolean DEFAULT_COMMAND_TREE_DEDUP_ENABLED = true;
             public static final String BATCH_WINDOW_MILLIS = "bandwidthoptimizer.transport.batchWindowMillis";
             public static final long DEFAULT_BATCH_WINDOW_MILLIS = 20L;
             public static final long DEFAULT_BATCH_WARMUP_MILLIS = 5_000L;

--- a/project/neoforge/26.1.2/src/main/java/com/PinkCats/bandwidthoptimizer/channel/ChannelTransportHooks.java
+++ b/project/neoforge/26.1.2/src/main/java/com/PinkCats/bandwidthoptimizer/channel/ChannelTransportHooks.java
@@ -1774,7 +1774,9 @@ public final class ChannelTransportHooks {
         if (!ChannelTransportBypassPacketList.shouldBypassTransparentTransport(packet)) {
             return false;
         }
-        ChannelTransportBatchManager.flushOutboundBatchNow(context);
+        if (!ChannelTransportBypassPacketList.mayOvertakePendingTransportBatch(packet)) {
+            ChannelTransportBatchManager.flushOutboundBatchNow(context);
+        }
         return true;
     }
 

--- a/project/neoforge/26.1.2/src/main/java/com/PinkCats/bandwidthoptimizer/mixin/minecraft/PacketOutPipeMixin.java
+++ b/project/neoforge/26.1.2/src/main/java/com/PinkCats/bandwidthoptimizer/mixin/minecraft/PacketOutPipeMixin.java
@@ -3,6 +3,8 @@ package com.PinkCats.bandwidthoptimizer.mixin.minecraft;
 import com.PinkCats.bandwidthoptimizer.channel.capture.ChannelCaptureHooks;
 import com.PinkCats.bandwidthoptimizer.channel.ChannelTransportHooks;
 import com.PinkCats.bandwidthoptimizer.channel.ChannelTransportStreamingEpochGate;
+import com.PinkCats.bandwidthoptimizer.channel.packet.ChannelTransportBypassPacketList;
+import com.PinkCats.bandwidthoptimizer.channel.packet.ClientboundCommandTreeDeduplicator;
 import com.PinkCats.bandwidthoptimizer.channel.access.PacketEncoderFlowAccess;
 import com.PinkCats.bandwidthoptimizer.channel.access.PacketEncoderProtocolInfoAccess;
 import com.PinkCats.bandwidthoptimizer.debug.HotpathCostProbe;
@@ -82,9 +84,19 @@ public abstract class PacketOutPipeMixin<T extends PacketListener> implements Pa
             return;
         }
         IdleGateBackgroundPacketGate.recordPassedPacket(context == null ? null : context.channel(), packet, this.protocolInfo.flow(), encodedByteLength);
+        if (ClientboundCommandTreeDeduplicator.tryDropDuplicate(
+                context,
+                packet,
+                this.protocolInfo.flow(),
+                out,
+                this.bandwidthoptimizer$writerIndexBefore
+        )) {
+            return;
+        }
         if (ChannelTransportStreamingEpochGate.deferIfClosed(
                 context,
-                ChannelTransportHooks.isInternalTransportCarrierPacket(packet),
+                ChannelTransportHooks.isInternalTransportCarrierPacket(packet)
+                        || ChannelTransportBypassPacketList.mayOvertakePendingTransportBatch(packet),
                 out,
                 this.bandwidthoptimizer$writerIndexBefore,
                 bytes -> ChannelTransportHooks.recordCommittedOutboundPacketStream(context, packet, bytes)

--- a/project/neoforge/26.2/build.gradle
+++ b/project/neoforge/26.2/build.gradle
@@ -65,6 +65,7 @@ def applySharedBandwidthOptimizerNeoForgeRunProperties = { Project projectRef, d
             ['boTransportMappingEnabled', 'bandwidthoptimizer.transport.mappingEnabled'],
             ['boTransportZstdEnabled', 'bandwidthoptimizer.transport.zstdEnabled'],
             ['boTransportBatchEnabled', 'bandwidthoptimizer.transport.batchEnabled'],
+            ['boTransportCommandTreeDedupEnabled', 'bandwidthoptimizer.transport.commandTreeDedupEnabled'],
             ['boTransportBatchWindowMillis', 'bandwidthoptimizer.transport.batchWindowMillis'],
             ['boTransportPacketIdMappingEnabled', 'bandwidthoptimizer.transport.packetIdMappingEnabled'],
             ['boTransportTelemetryDumpFileName', 'bandwidthoptimizer.transport.telemetryDumpFileName'],
@@ -535,6 +536,15 @@ tasks.register('runCrossFrameZstdRegression', JavaExec) {
     dependsOn(tasks.named('testClasses'))
     classpath = files(sourceSets.test.output, sourceSets.main.runtimeClasspath, sourceSets.test.runtimeClasspath)
     mainClass = 'com.PinkCats.bandwidthoptimizer.test.CrossFrameZstdRegressionMain'
+    javaLauncher = boJava25Launcher
+}
+
+tasks.register('runClientboundCommandTreeDeduplicatorRegression', JavaExec) {
+    group = 'verification'
+    description = 'Verifies final-byte command-tree deduplication, connection epochs, concurrency, and KeepAlive queue priority.'
+    dependsOn(tasks.named('testClasses'))
+    classpath = files(sourceSets.test.output, sourceSets.main.runtimeClasspath, sourceSets.test.runtimeClasspath)
+    mainClass = 'com.PinkCats.bandwidthoptimizer.channel.packet.ClientboundCommandTreeDeduplicatorRegressionMain'
     javaLauncher = boJava25Launcher
 }
 

--- a/project/neoforge/26.2/src/main/java/com/PinkCats/bandwidthoptimizer/Config.java
+++ b/project/neoforge/26.2/src/main/java/com/PinkCats/bandwidthoptimizer/Config.java
@@ -300,6 +300,9 @@ public class Config {
             public static final boolean DEFAULT_PACKET_ID_MAPPING_ENABLED = true;
             public static final String BATCH_ENABLED = "bandwidthoptimizer.transport.batchEnabled";
             public static final boolean DEFAULT_BATCH_ENABLED = true;
+            public static final String COMMAND_TREE_DEDUP_ENABLED =
+                    "bandwidthoptimizer.transport.commandTreeDedupEnabled";
+            public static final boolean DEFAULT_COMMAND_TREE_DEDUP_ENABLED = true;
             public static final String BATCH_WINDOW_MILLIS = "bandwidthoptimizer.transport.batchWindowMillis";
             public static final long DEFAULT_BATCH_WINDOW_MILLIS = 20L;
             public static final long DEFAULT_BATCH_WARMUP_MILLIS = 5_000L;

--- a/project/neoforge/26.2/src/main/java/com/PinkCats/bandwidthoptimizer/channel/ChannelTransportHooks.java
+++ b/project/neoforge/26.2/src/main/java/com/PinkCats/bandwidthoptimizer/channel/ChannelTransportHooks.java
@@ -1774,7 +1774,9 @@ public final class ChannelTransportHooks {
         if (!ChannelTransportBypassPacketList.shouldBypassTransparentTransport(packet)) {
             return false;
         }
-        ChannelTransportBatchManager.flushOutboundBatchNow(context);
+        if (!ChannelTransportBypassPacketList.mayOvertakePendingTransportBatch(packet)) {
+            ChannelTransportBatchManager.flushOutboundBatchNow(context);
+        }
         return true;
     }
 

--- a/project/neoforge/26.2/src/main/java/com/PinkCats/bandwidthoptimizer/mixin/minecraft/PacketOutPipeMixin.java
+++ b/project/neoforge/26.2/src/main/java/com/PinkCats/bandwidthoptimizer/mixin/minecraft/PacketOutPipeMixin.java
@@ -3,6 +3,8 @@ package com.PinkCats.bandwidthoptimizer.mixin.minecraft;
 import com.PinkCats.bandwidthoptimizer.channel.capture.ChannelCaptureHooks;
 import com.PinkCats.bandwidthoptimizer.channel.ChannelTransportHooks;
 import com.PinkCats.bandwidthoptimizer.channel.ChannelTransportStreamingEpochGate;
+import com.PinkCats.bandwidthoptimizer.channel.packet.ChannelTransportBypassPacketList;
+import com.PinkCats.bandwidthoptimizer.channel.packet.ClientboundCommandTreeDeduplicator;
 import com.PinkCats.bandwidthoptimizer.channel.access.PacketEncoderFlowAccess;
 import com.PinkCats.bandwidthoptimizer.channel.access.PacketEncoderProtocolInfoAccess;
 import com.PinkCats.bandwidthoptimizer.debug.HotpathCostProbe;
@@ -82,9 +84,19 @@ public abstract class PacketOutPipeMixin<T extends PacketListener> implements Pa
             return;
         }
         IdleGateBackgroundPacketGate.recordPassedPacket(context == null ? null : context.channel(), packet, this.protocolInfo.flow(), encodedByteLength);
+        if (ClientboundCommandTreeDeduplicator.tryDropDuplicate(
+                context,
+                packet,
+                this.protocolInfo.flow(),
+                out,
+                this.bandwidthoptimizer$writerIndexBefore
+        )) {
+            return;
+        }
         if (ChannelTransportStreamingEpochGate.deferIfClosed(
                 context,
-                ChannelTransportHooks.isInternalTransportCarrierPacket(packet),
+                ChannelTransportHooks.isInternalTransportCarrierPacket(packet)
+                        || ChannelTransportBypassPacketList.mayOvertakePendingTransportBatch(packet),
                 out,
                 this.bandwidthoptimizer$writerIndexBefore,
                 bytes -> ChannelTransportHooks.recordCommittedOutboundPacketStream(context, packet, bytes)

--- a/test.gradle
+++ b/test.gradle
@@ -85,6 +85,7 @@ def applySharedBandwidthOptimizerRunProperties = { Project projectRef, def runCo
             ['boTransportMappingEnabled', 'bandwidthoptimizer.transport.mappingEnabled'],
             ['boTransportZstdEnabled', 'bandwidthoptimizer.transport.zstdEnabled'],
             ['boTransportBatchEnabled', 'bandwidthoptimizer.transport.batchEnabled'],
+            ['boTransportCommandTreeDedupEnabled', 'bandwidthoptimizer.transport.commandTreeDedupEnabled'],
             ['boTransportBatchWindowMillis', 'bandwidthoptimizer.transport.batchWindowMillis'],
             ['boTransportPacketIdMappingEnabled', 'bandwidthoptimizer.transport.packetIdMappingEnabled'],
             ['boTestStreamingZstd', 'bandwidthoptimizer.test.streamingZstd'],
@@ -161,6 +162,15 @@ def configureTestJavaExecTask = { JavaExec taskRef, String groupName, String tas
     taskRef.dependsOn(tasks.named('testClasses'))
     taskRef.classpath = sourceSets.test.runtimeClasspath
     taskRef.mainClass = mainClassName
+}
+
+tasks.register('runClientboundCommandTreeDeduplicatorRegression', JavaExec) {
+    configureTestJavaExecTask(
+            delegate,
+            'verification',
+            'Verifies final-byte command-tree deduplication, connection epochs, concurrency, and KeepAlive queue priority.',
+            'com.PinkCats.bandwidthoptimizer.channel.packet.ClientboundCommandTreeDeduplicatorRegressionMain'
+    )
 }
 
 tasks.register('runChannelSimulate', JavaExec) {


### PR DESCRIPTION
## 背景

一次 20 秒、8 次跨维度传送的抓包中，`ClientboundCommandsPacket` 出现 12 次，共 1.49 MiB raw/actual；现有透明传输又会在 KeepAlive 前同步提交 BO 待发送批次。区块压缩本身已经有效，因此本 PR 聚焦两个 P0 热点：重复命令树和 BO 自有队列对 KeepAlive 的额外排队。

## 实现

### 1. 按连接去重最终编码后的命令树

- 在六套发布源码的 `PacketOutPipeMixin` 编码完成点读取当前玩家真正会收到的最终字节，不比较全局 dispatcher，也不依赖权限版本号。
- 每个 Netty `Channel` 只保存 `encodedLength + SHA-256`（32 字节摘要），相同长度且摘要相同才丢弃；内容发生变化立即正常发送。
- 状态更新使用每连接 CAS；热路径没有 I/O、等待、线程切换、定时器或全局锁，也不缓存整棵命令树。
- 登录和重新进入 configuration 阶段会清空连接 epoch；断线后状态随 Channel 回收。
- 哈希实现异常时 fail-open：包继续发送并记录一次警告，不会因优化失败破坏命令同步。
- 新增命中数、避免字节数、哈希耗时、epoch reset 和失败数等进程内遥测快照。

### 2. KeepAlive 绕过 BO 自有待发送队列

- KeepAlive 不再为 BO 的 transport batch 触发“先 flush 旧批次再发送”，也不等待 streaming epoch ACK。
- 只允许现代/旧版 `ClientboundKeepAlivePacket` 使用该策略；命令树、状态包、区块和自定义 payload 仍保持原有顺序。
- 该策略只越过尚未提交的 BO 队列，不重排已经写入 Netty outbound buffer/操作系统的字节。
- Respawn、Position 等有状态控制包继续走 BO 已有 boundary/force-direct 逻辑，避免用一个宽泛优先队列破坏协议顺序。

### 3. 可回滚开关

默认启用，可通过以下 JVM 参数立即 fail-open 回退命令树去重：

```text
-Dbandwidthoptimizer.transport.commandTreeDedupEnabled=false
```

KeepAlive 改动没有新增线程、队列、缓存或线协议，客户端/服务端 BO 握手格式不变。

## 回归覆盖

新增的确定性回归覆盖：

- 首包发送、相同最终字节丢弃；
- 同长度但内容变化、A → B → A；
- 登录/configuration epoch reset；
- 配置关闭时 fail-open、重新启用后的首包；
- 连接隔离；
- 12 线程同时观察同一首包时只有一个发送者；
- composite/direct `ByteBuf`；
- KeepAlive 的新旧类名策略；
- closed streaming epoch 下 KeepAlive 直通、普通状态仍延后并按序 replay。

七个发布目标均实际运行通过：

```powershell
.\gradlew.bat :forge-1.19.2:runClientboundCommandTreeDeduplicatorRegression :forge-1.20.1:runClientboundCommandTreeDeduplicatorRegression :fabric-1.20.1:runClientboundCommandTreeDeduplicatorRegression :fabric-1.21.1:runClientboundCommandTreeDeduplicatorRegression :neoforge-1.21.1:runClientboundCommandTreeDeduplicatorRegression :neoforge-26.1.2:runClientboundCommandTreeDeduplicatorRegression :neoforge-26.2:runClientboundCommandTreeDeduplicatorRegression --stacktrace
```

现有 transport/zstd 回归通过：

```powershell
.\gradlew.bat :forge-1.20.1:runChannelTransportRoundTrip :fabric-1.21.1:runChannelTransportRoundTrip :neoforge-1.21.1:runCrossFrameZstdRegression :neoforge-26.2:runCrossFrameZstdRegression --stacktrace
```

实际发布产物任务通过：

```powershell
.\gradlew.bat :forge-1.19.2:build :forge-1.20.1:build :fabric-1.20.1:remapJar :fabric-1.21.1:remapJar :neoforge-1.21.1:build :neoforge-26.1.2:build :neoforge-26.2:build --stacktrace
```

说明：仓库根 `gradlew build` 仍会在 Fabric 1.20.1 的 `sourcesJar` 报既有 Gradle 隐式依赖问题（`prepareEmbeddedRuntimeLibs` 输出未声明为依赖）；本 PR 未修改该 sourcesJar 配置。上面的七套实际发布产物任务均成功。

## 性能预期与验证边界

若报告中的 12 个 1.49 MiB 命令树最终字节完全相同，本实现会发送第一份并丢弃后续 11 份，理论上减少约 91.7% 的命令树次数/字节；如果权限或内容变化，则只发送真正变化的版本。

本地回归和构建不能证明真实网络 SLA。本 PR 尚未在原报告的 Youer + Multiverse + LuckPerms 环境重跑 20 秒 A/B，因此“命令树 actual bytes 至少降低 80%”“KeepAlive 最大排队小于 100 ms”“总 actual frame 降低 25%”仍需用相同抓包流程验收。KeepAlive 也无法越过已经提交给 Netty/OS 的字节，本 PR 消除的是 BO 自有 batch 和 streaming gate 引入的额外等待。
